### PR TITLE
Bump software versions, add ability to customize manager instance IMD…

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,11 @@ Please refer to the `examples` folder for a complete example.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aggregated_policy"></a> [aggregated\_policy](#module\_aggregated\_policy) | cloudposse/iam-policy-document-aggregator/aws | 0.8.0 |
-| <a name="module_auth_token_ssm_param_label"></a> [auth\_token\_ssm\_param\_label](#module\_auth\_token\_ssm\_param\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_default_label"></a> [default\_label](#module\_default\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_auth_token_ssm_param_label"></a> [auth\_token\_ssm\_param\_label](#module\_auth\_token\_ssm\_param\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_default_label"></a> [default\_label](#module\_default\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_manager_instance"></a> [manager\_instance](#module\_manager\_instance) | cloudposse/ec2-instance/aws | 0.30.4 |
-| <a name="module_manager_label"></a> [manager\_label](#module\_manager\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_runner_label"></a> [runner\_label](#module\_runner\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_manager_label"></a> [manager\_label](#module\_manager\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_runner_label"></a> [runner\_label](#module\_runner\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_s3_cache_bucket"></a> [s3\_cache\_bucket](#module\_s3\_cache\_bucket) | cloudposse/s3-bucket/aws | 0.33.0 |
 
 ## Resources
@@ -260,14 +260,14 @@ Please refer to the `examples` folder for a complete example.
 | <a name="input_create_autoscaling_service_linked_role"></a> [create\_autoscaling\_service\_linked\_role](#input\_create\_autoscaling\_service\_linked\_role) | Defines whether to create service-linked role for EC2 autoscaling | `bool` | `true` | no |
 | <a name="input_create_spot_service_linked_role"></a> [create\_spot\_service\_linked\_role](#input\_create\_spot\_service\_linked\_role) | Defines whether to create service-linked role for EC2 spot instances | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `name`, `stage` and `attributes` | `string` | `"-"` | no |
-| <a name="input_docker_machine_version"></a> [docker\_machine\_version](#input\_docker\_machine\_version) | Docker machine version to be installed on manager instance | `string` | `"0.16.2-gitlab.11"` | no |
+| <a name="input_docker_machine_version"></a> [docker\_machine\_version](#input\_docker\_machine\_version) | Docker machine version to be installed on manager instance | `string` | `"0.16.2-gitlab.13"` | no |
 | <a name="input_enable_access_to_ecr_repositories"></a> [enable\_access\_to\_ecr\_repositories](#input\_enable\_access\_to\_ecr\_repositories) | A list of ECR repositories in specified `region` that manager instance should have read-only access to | `list(string)` | `[]` | no |
 | <a name="input_enable_cloudwatch_logs"></a> [enable\_cloudwatch\_logs](#input\_enable\_cloudwatch\_logs) | Defines whether manager instance should ship its logs to Cloudwatch | `bool` | `true` | no |
 | <a name="input_enable_s3_cache"></a> [enable\_s3\_cache](#input\_enable\_s3\_cache) | Defines whether s3 should be created and used as a source for distributed cache | `bool` | `true` | no |
 | <a name="input_enable_ssm_sessions"></a> [enable\_ssm\_sessions](#input\_enable\_ssm\_sessions) | Defines whether access via SSM Session Manager should be enabled for manager instance | `bool` | `true` | no |
-| <a name="input_gitlab_runner_version"></a> [gitlab\_runner\_version](#input\_gitlab\_runner\_version) | Gitlab runner version to be installed on manager instance | `string` | `"13.10.0"` | no |
+| <a name="input_gitlab_runner_version"></a> [gitlab\_runner\_version](#input\_gitlab\_runner\_version) | Gitlab runner version to be installed on manager instance | `string` | `"14.2.0"` | no |
 | <a name="input_gitlab_url"></a> [gitlab\_url](#input\_gitlab\_url) | Gitlab URL | `string` | `"https://gitlab.com"` | no |
-| <a name="input_manager"></a> [manager](#input\_manager) | Runners' manager (aka bastion) configuration | <pre>object({<br>    ami_id                      = string<br>    ami_owner                   = string<br>    instance_type               = string<br>    key_pair                    = string<br>    subnet_id                   = string<br>    associate_public_ip_address = bool<br>    assign_eip_address          = bool<br>    root_volume_size            = number<br>    ebs_optimized               = bool<br>    enable_detailed_monitoring  = bool<br>  })</pre> | n/a | yes |
+| <a name="input_manager"></a> [manager](#input\_manager) | Runners' manager (aka bastion) configuration | <pre>object({<br>    ami_id                               = string<br>    ami_owner                            = string<br>    instance_type                        = string<br>    key_pair                             = string<br>    subnet_id                            = string<br>    associate_public_ip_address          = bool<br>    assign_eip_address                   = bool<br>    root_volume_size                     = number<br>    ebs_optimized                        = bool<br>    enable_detailed_monitoring           = bool<br>    metadata_http_endpoint_enabled       = bool<br>    metadata_http_put_response_hop_limit = number<br>    metadata_http_tokens_required        = bool<br>  })</pre> | n/a | yes |
 | <a name="input_metrics_port"></a> [metrics\_port](#input\_metrics\_port) | See https://docs.gitlab.com/runner/monitoring/#configuration-of-the-metrics-http-server for more details | `number` | `9252` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |

--- a/ec2_instance.tf
+++ b/ec2_instance.tf
@@ -29,7 +29,7 @@ data "aws_kms_key" "registration_token" {
 
 module "manager_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   context    = module.default_label.context
   attributes = compact(concat(var.attributes, ["manager"]))
@@ -37,7 +37,7 @@ module "manager_label" {
 
 module "runner_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   context    = module.default_label.context
   attributes = compact(concat(var.attributes, ["runner"]))
@@ -78,6 +78,10 @@ module "manager_instance" {
   ebs_optimized    = var.manager.ebs_optimized
 
   user_data = local.manager_user_data_template_rendered
+
+  metadata_http_endpoint_enabled       = var.manager.metadata_http_endpoint_enabled
+  metadata_http_put_response_hop_limit = var.manager.metadata_http_put_response_hop_limit
+  metadata_http_tokens_required        = var.manager.metadata_http_tokens_required
 }
 
 #############################################################
@@ -329,7 +333,7 @@ resource "aws_security_group_rule" "manager_egress" {
   to_port          = 0
   protocol         = "-1"
   cidr_blocks      = ["0.0.0.0/0"] #tfsec:ignore:AWS007
-  ipv6_cidr_blocks = ["::/0"]
+  ipv6_cidr_blocks = ["::/0"]      #tfsec:ignore:AWS007
   description      = "Allow all egress traffic"
 }
 
@@ -375,7 +379,7 @@ resource "aws_security_group_rule" "runners_egress" {
   to_port          = 0
   protocol         = "-1"
   cidr_blocks      = ["0.0.0.0/0"] #tfsec:ignore:AWS007
-  ipv6_cidr_blocks = ["::/0"]
+  ipv6_cidr_blocks = ["::/0"]      #tfsec:ignore:AWS007
   description      = "Allow all egress"
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -52,16 +52,19 @@ module "runner" {
   }
 
   manager = {
-    ami_id                      = "ami-0518bb0e75d3619ca"
-    ami_owner                   = "amazon"
-    instance_type               = "t3a.micro"
-    key_pair                    = null
-    subnet_id                   = lookup(module.subnets.az_subnet_ids, join("", [data.aws_region.current.name, var.aws_az]))
-    associate_public_ip_address = true
-    assign_eip_address          = false
-    enable_detailed_monitoring  = false
-    root_volume_size            = 8
-    ebs_optimized               = false
+    ami_id                               = "ami-0518bb0e75d3619ca"
+    ami_owner                            = "amazon"
+    instance_type                        = "t3a.micro"
+    key_pair                             = null
+    subnet_id                            = lookup(module.subnets.az_subnet_ids, join("", [data.aws_region.current.name, var.aws_az]))
+    associate_public_ip_address          = true
+    assign_eip_address                   = false
+    enable_detailed_monitoring           = false
+    root_volume_size                     = 8
+    ebs_optimized                        = false
+    metadata_http_endpoint_enabled       = true
+    metadata_http_put_response_hop_limit = 2
+    metadata_http_tokens_required        = true
   }
 
   runner = {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,9 @@
 #############################################################
 
 locals {
-  authentication_token_ssm_param                  = var.authentication_token_ssm_param != null ? var.authentication_token_ssm_param : "/${module.auth_token_ssm_param_label.id}"
+  #tfsec:ignore:GEN002
+  authentication_token_ssm_param = var.authentication_token_ssm_param != null ? var.authentication_token_ssm_param : "/${module.auth_token_ssm_param_label.id}"
+  #tfsec:ignore:GEN002
   authentication_token_ssm_param_kms_key_provided = var.authentication_token_ssm_param_kms_key != null ? true : false
 }
 
@@ -13,7 +15,7 @@ locals {
 
 module "default_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   attributes = var.attributes
   delimiter  = var.delimiter
@@ -27,7 +29,7 @@ module "auth_token_ssm_param_label" {
   enabled = var.authentication_token_ssm_param != null ? false : true
 
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   context    = module.default_label.context
   attributes = compact(concat(var.attributes, ["auth_token"]))

--- a/variables.tf
+++ b/variables.tf
@@ -86,16 +86,19 @@ variable "vpc" {
 variable "manager" {
   description = "Runners' manager (aka bastion) configuration"
   type = object({
-    ami_id                      = string
-    ami_owner                   = string
-    instance_type               = string
-    key_pair                    = string
-    subnet_id                   = string
-    associate_public_ip_address = bool
-    assign_eip_address          = bool
-    root_volume_size            = number
-    ebs_optimized               = bool
-    enable_detailed_monitoring  = bool
+    ami_id                               = string
+    ami_owner                            = string
+    instance_type                        = string
+    key_pair                             = string
+    subnet_id                            = string
+    associate_public_ip_address          = bool
+    assign_eip_address                   = bool
+    root_volume_size                     = number
+    ebs_optimized                        = bool
+    enable_detailed_monitoring           = bool
+    metadata_http_endpoint_enabled       = bool
+    metadata_http_put_response_hop_limit = number
+    metadata_http_tokens_required        = bool
   })
 }
 
@@ -173,13 +176,13 @@ variable "runner_advanced_config" {
 }
 
 variable "docker_machine_version" {
-  default     = "0.16.2-gitlab.11"
+  default     = "0.16.2-gitlab.13"
   type        = string
   description = "Docker machine version to be installed on manager instance"
 }
 
 variable "gitlab_runner_version" {
-  default     = "13.10.0"
+  default     = "14.2.0"
   type        = string
   description = "Gitlab runner version to be installed on manager instance"
 }


### PR DESCRIPTION
- Allow customization of manager instance IMDS parameters (related issue: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/16097)
- Bump null label modules to 0.25.0
- Bump default docker-machine version to 0.16.2-gitlab.13
- Bump default gitlab runner version to 14.2.0
